### PR TITLE
Format comment body as quote rather than as code

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ If you ran hubot using shell-adapter, you will receive a message like below on y
 ```
 hubot> *key summary* _(http://172.16.45.12/jira/browse/key)_
 @mnpk's comment:
-```hello,hubot-jira-comment```
+>>>
+hello,hubot-jira-comment
 ```
 
 

--- a/src/hubot-jira-comment.coffee
+++ b/src/hubot-jira-comment.coffee
@@ -20,5 +20,5 @@ module.exports = (robot) ->
     if body.webhookEvent == 'jira:issue_updated' && body.comment
       issue = "#{body.issue.key} #{body.issue.fields.summary}"
       url = "#{process.env.HUBOT_JIRA_URL}/browse/#{body.issue.key}"
-      robot.messageRoom room, "*#{issue}* _(#{url})_\n@#{body.comment.author.name}'s comment:\n```#{body.comment.body}```"
+      robot.messageRoom room, "*#{issue}* _(#{url})_\n@#{body.comment.author.name}'s comment:\n>>>\n#{body.comment.body}"
     res.send 'OK'


### PR DESCRIPTION
Just noticed that the comment was being formatted as a code block rather than as a quote.
