### PR TITLE
Jira changed the webhook event names for comments

### DIFF
--- a/src/hubot-jira-comment.coffee
+++ b/src/hubot-jira-comment.coffee
@@ -17,7 +17,8 @@ module.exports = (robot) ->
   robot.router.post '/hubot/chat-jira-comment/:room', (req, res) ->
     room = req.params.room
     body = req.body
-    if body.webhookEvent == 'jira:issue_updated' && body.comment
+    match = /^comment/.test(body.webhookEvent)
+    if match && body.comment
       issue = "#{body.issue.key} #{body.issue.fields.summary}"
       url = "#{process.env.HUBOT_JIRA_URL}/browse/#{body.issue.key}"
       content = body.comment.body.replace(/\[~([a-zA-Z0-9]+)\]/g,'@$1')


### PR DESCRIPTION
Atlassian seems to have [changed the `webhookEvent` names](https://developer.atlassian.com/server/jira/platform/webhooks/) that they use for comments. They all start with "comment_" now.

The change caused this hubot script to stop firing. This PR fixes the issue.